### PR TITLE
Fixed check in the total case of derive

### DIFF
--- a/src/et_al/Tableau.rsc
+++ b/src/et_al/Tableau.rsc
@@ -125,7 +125,7 @@ Tableau derive(T(total(str f, str t)), Var a, Var b)
 
 Tableau derive(T(total(str f, str t)), Var a, Var b)
   = alt({})
-  when a.class != f, b.class != t;
+  when a.class != f || b.class != t;
 
 Tableau derive(F(total(str f, str t)), Var a, Var b)
   = seq({})


### PR DESCRIPTION
Switched the conjunction to a disjunction, because only one of the variables class has to be incompatible and not both, as far as I understand the code.